### PR TITLE
Improvement/extend api to support url redirects

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -128,6 +128,13 @@ export default {
     },
     engagements: {
       create: `${defaultApiHost}/engagements/v1/engagements`
+    },
+    urlMappings: {
+      getAll: `${defaultApiHost}/url-mappings/v3/url-mappings`,
+      byId: `${defaultApiHost}/url-mappings/v3/url-mappings/{id}`,
+      create: `${defaultApiHost}/url-mappings/v3/url-mappings`,
+      update: `${defaultApiHost}/url-mappings/v3/url-mappings/{id}`,
+      delete: `${defaultApiHost}/url-mappings/v3/url-mappings/{id}`,
     }
   }
 };

--- a/src/entities/url-mappings.js
+++ b/src/entities/url-mappings.js
@@ -156,6 +156,7 @@ export default function urlMappingApi(baseOptions) {
     * @property {int} opts.id,
     * @property {int} opts.routePrefix,
     * @property {int} opts.destination
+    *  @returns {Promise}
     */ 
     getUrlMappings,
     /**

--- a/src/entities/url-mappings.js
+++ b/src/entities/url-mappings.js
@@ -1,0 +1,97 @@
+import createRequest, {
+  queryStringParamInterpolator,
+  requiresAuthentication
+} from '../utilities';
+import constants from '../constants';
+
+const defaults = {};
+let _baseOptions;
+
+const getUrlMappings = async (opts = {}) => {
+  try {
+    requiresAuthentication(_baseOptions);
+    const {
+      limit,
+      offset,
+      id,
+      routePrefix,
+      destination
+    } = opts;
+    let additionalOpts = {
+      limit,
+      offset,
+      id,
+      routePrefix,
+      destination
+    };
+
+    const mergedProps = Object.assign(
+      {},
+      defaults,
+      _baseOptions,
+      additionalOpts
+    );
+    const urlMappings = await createRequest(
+      constants.api.urlMappings.getAll,
+      {},
+      mergedProps
+    );
+
+    return Promise.resolve(urlMappings);
+  } catch (e) {
+    return Promise.reject(e.message);
+  }
+};
+
+const getUrlMapping = async id => {
+  try {
+    requiresAuthentication(_baseOptions);
+    if (!id) {
+      throw new Error('getUrlMapping requires an `id` argument');
+    }
+    const mergedProps = Object.assign({}, defaults, _baseOptions);
+    const urlMapping = await createRequest(
+      constants.api.urlMappings.byId,
+      { id },
+      mergedProps
+    );
+    return Promise.resolve(urlMapping);
+  } catch (e) {
+    return Promise.reject(e.message);
+  }
+};
+
+
+export default function urlMappingApi(baseOptions) {
+  _baseOptions = baseOptions;
+
+  return {
+    /**
+    * Get URL Mappings for a portal
+    * @async
+    * @memberof hs/domains
+    * @method getUrlMappings
+    * @param {object} opts
+    * @example
+    * const hs = new HubspotClient(props);
+    * @property {int} opts.limit,
+    * @property {int} opts.offset,
+    * @property {int} opts.id,
+    * @property {int} opts.routePrefix,
+    * @property {int} opts.destination
+    */ 
+    getUrlMappings,
+    /**
+     * Get URL Mapping by ID
+     * @async
+     * @memberof hs/domains
+     * @method getUrlMapping
+     * @param {int} UrlMappingId
+     * @example
+     * const hs = new HubspotClient(props);
+     * hs.domains.getUrlMapping(UrlMappingId).then(response => console.log(response));
+     * @returns {Promise}
+     */
+    getUrlMapping,
+    };
+  }

--- a/src/entities/url-mappings.js
+++ b/src/entities/url-mappings.js
@@ -1,11 +1,54 @@
 import createRequest, {
-  queryStringParamInterpolator,
   requiresAuthentication
 } from '../utilities';
 import constants from '../constants';
 
 const defaults = {};
 let _baseOptions;
+
+const createOrUpdateUrlMapping = async (opts = {}) => {
+  try {
+    requiresAuthentication(_baseOptions);
+    const {
+      routePrefix,
+      destination,
+      redirectStyle,
+      isMatchFullUrl,
+      isMatchQueryString,
+      isOnlyAfterNotFound,
+      isPattern,
+      precedence
+    } = opts;
+
+    const body = {
+      routePrefix,
+      destination,
+      redirectStyle,
+      isMatchFullUrl,
+      isMatchQueryString,
+      isOnlyAfterNotFound,
+      isPattern,
+      precedence
+    };
+
+    let method = 'POST';
+    let url = constants.api.urlMappings.create;
+
+    const options = { method, body };
+    if (id) {
+      method = 'PUT';
+      url = constants.api.urlMappings.byId;
+      Object.assign(options, { method, id });
+    }
+
+    const mergedProps = Object.assign({}, defaults, _baseOptions);
+    const update = await createRequest(url, options, mergedProps);
+
+    return Promise.resolve(update);
+  } catch (e) {
+    return Promise.reject(e.message);
+  }
+};
 
 const getUrlMappings = async (opts = {}) => {
   try {
@@ -43,11 +86,11 @@ const getUrlMappings = async (opts = {}) => {
   }
 };
 
-const getUrlMapping = async id => {
+const getUrlMappingById = async id => {
   try {
     requiresAuthentication(_baseOptions);
     if (!id) {
-      throw new Error('getUrlMapping requires an `id` argument');
+      throw new Error('getUrlMappingById requires an `id` argument');
     }
     const mergedProps = Object.assign({}, defaults, _baseOptions);
     const urlMapping = await createRequest(
@@ -61,15 +104,49 @@ const getUrlMapping = async id => {
   }
 };
 
+const deleteUrlMapping = async id => {
+  try {
+    requiresAuthentication(_baseOptions);
+    const mergedProps = Object.assign({}, defaults, _baseOptions);
+    await createRequest(
+      constants.api.pages.byId,
+      { url_mapping_id, method: 'DELETE' },
+      mergedProps
+    );
+    return Promise.resolve({ deleted: true });
+  } catch (e) {
+    return Promise.reject(e.message);
+  }
+};
 
 export default function urlMappingApi(baseOptions) {
   _baseOptions = baseOptions;
 
   return {
     /**
+    * Create a new url mapping or update an existing url mapping
+    * @memberof hs/urlMappings
+    * @method createOrUpdateUrlMapping
+    * @param {object} opts
+    * @example
+    * const hs = new HubspotClient(props);
+    * hs.pages.createOrUpdateUrlMapping(opts).then(response => console.log(response));
+    * @property {int} opts.id If set, this will update the page with the corresponding ID.
+    * @property {int} opts.routePrefix,
+    *  @property {int} opts.destination,
+    *  @property {int} opts.redirectStyle,
+    *  @property {int} opts.isMatchFullUrl,
+    *  @property {int} opts.isMatchQueryString,
+    *  @property {int} opts.isOnlyAfterNotFound,
+    *  @property {int} opts.isPattern,
+    *  @property {int} opts.precedence
+    * @returns {Promise}
+    */
+    createOrUpdateUrlMapping,
+    /**
     * Get URL Mappings for a portal
     * @async
-    * @memberof hs/domains
+    * @memberof hs/urlMappings
     * @method getUrlMappings
     * @param {object} opts
     * @example
@@ -84,14 +161,26 @@ export default function urlMappingApi(baseOptions) {
     /**
      * Get URL Mapping by ID
      * @async
-     * @memberof hs/domains
+     * @memberof hs/urlMappings
      * @method getUrlMapping
      * @param {int} UrlMappingId
      * @example
      * const hs = new HubspotClient(props);
-     * hs.domains.getUrlMapping(UrlMappingId).then(response => console.log(response));
+     * hs.urlMappings.getUrlMapping(UrlMappingId).then(response => console.log(response));
      * @returns {Promise}
      */
-    getUrlMapping,
+    getUrlMappingById,
+    /**
+     * Retrieve page info by ID
+     * @async
+     * @memberof hs/urlMappings
+     * @method deleteUrlMapping
+     * @param {int} id
+     * @example
+     * const hs = new HubspotClient(props);
+     * hs.pages.deleteUrlMapping(id).then(response => console.log(response))
+     * @returns {Promise}
+     */
+    deleteUrlMapping
     };
   }


### PR DESCRIPTION
Extends the api to support the URL Redirects feature as seen here: https://developers.hubspot.com/docs/methods/url-mappings/get_url_mappings

Added in the functionality to:
-   getUrlMapping(s)  (As a group)
-   getURLMappingById (Singular)
-   createOrUpdate a URL Mapping (Singular)
-   deleteURLMapping (Singular)

This was a net-new asset so I created it's own file structure, as opposed to creating it under "Domains". 