### PR TITLE
Update API host paths to `api.hubspot.com`

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-const defaultApiHost = process.env.COS_API_HOST || 'https://api.hubapi.com';
+const defaultApiHost = process.env.COS_API_HOST || 'https://api.hubspot.com';
 
 export default {
   api: {


### PR DESCRIPTION
Update API host paths to `api.hubspot.com` 
Reference: [issue 40](https://github.com/HubSpotWebTeam/hs-node-api/issues/40)