### PR TITLE
Revert "Update API host paths to `api.hubspot.com`"

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-const defaultApiHost = process.env.COS_API_HOST || 'https://api.hubspot.com';
+const defaultApiHost = process.env.COS_API_HOST || 'https://api.hubapi.com';
 
 export default {
   api: {


### PR DESCRIPTION
Reverts HubSpotWebTeam/hs-node-api#41
As requested in the [PR](https://github.com/HubSpotWebTeam/hs-node-api/issues/40)

> Would you be able to revert this API host change? It looks like api.hubapi.com is still the better host for external integrators/requests. It's possible that any .hubspot.com host may be subject to stricter security settings down the line (e.g. if CORS settings were updated to validate these on internal domains).

@pwilver @smcelhinney 