### PR TITLE
Changed URL for recently modified contacts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -117,7 +117,7 @@ export default {
       byUtk: `${defaultApiHost}/contacts/v1/contact/utk/{utk}/profile`,
       createContact: `${defaultApiHost}/contacts/v1/contact/createOrUpdate/email/{email}/`,
       batchUpdateContacts: `${defaultApiHost}/contacts/v1/contact/batch/`,
-      getRecentlyModified: `${defaultApiHost}/contacts/v1/lists/recently_updated/contacts/recent`,
+      getRecentlyModified: `${defaultApiHost}/contacts/v1/lists/all/contacts/recent`,
       search: `${defaultApiHost}/contacts/v1/search/query`
     },
     contactsList: {


### PR DESCRIPTION
Modified URL so it matches official documentation (https://developers.hubspot.com/docs/methods/contacts/get_recently_created_contacts).
The call didn't work with the previous URL (404).