### PR TITLE
Add transactional email single send

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # How to Contribute
+
 1. Fork the project & clone locally
 
-2. Create an upstream remote and sync your local copy before you branch 
+2. Create an upstream remote and sync your local copy before you branch
+
     ```sh
     git remote add upstream git@github.com:HubSpotWebTeam/hs-node-api.git
     ```
-    
+
 3. Create a `.env` file in the root of your folder for all `process.env` tokens, such as the HAPIkey. e.g.
     ```
     E2E_TESTS_HAPI_KEY="your-hapi-key"
@@ -19,11 +21,12 @@
     E2E_TESTS_LAYOUT_VERSION_ID="1234567894"
     E2E_TESTS_PAGE_ID="1234567"
     E2E_TESTS_TEMPLATE_PATH="generated_layouts/1234567.html"
+    E2E_TESTS_EMAIL_ID=""
     ```
-3. Create a new branch for each separate piece of work following the convention `contribution_type/some-detail` e.g. `improvement/update-contribution-docs`
+4. Create a new branch for each separate piece of work following the convention `contribution_type/some-detail` e.g. `improvement/update-contribution-docs`
 
-4. Make your changes & ensure tests are passing 
+5. Make your changes & ensure tests are passing
     ```sh
     npm run build && npm test
     ```
-5. Create a new PR in GitHub and within the body notify one of the repo maintainers
+6. Create a new PR in GitHub and within the body notify one of the repo maintainers

--- a/src/constants.js
+++ b/src/constants.js
@@ -76,6 +76,9 @@ export default {
     email: {
       getSubscriptions: `${defaultApiHost}/email/public/v1/subscriptions`
     },
+    transactionalEmail: {
+      singleSend: `${defaultApiHost}/email/public/v1/singleEmail/send`
+    },
     blog: {
       authors: `${defaultApiHost}/blogs/v3/blog-authors`,
       authorById: `${defaultApiHost}/blogs/v3/blog-authors/{id}`,

--- a/src/entities/transactional-emails.js
+++ b/src/entities/transactional-emails.js
@@ -1,0 +1,50 @@
+
+import createRequest, { requiresAuthentication } from '../utilities';
+import constants from '../constants';
+
+let _baseOptions;
+
+const singleSend = async (emailId, message, contactProperties, customProperties) => {
+  try {
+    requiresAuthentication(_baseOptions);
+    const method = 'POST';
+    const response = await createRequest(
+      constants.api.transactionalEmail.singleSend,
+      {
+        method,
+        body: {
+          emailId,
+          message,
+          contactProperties,
+          customProperties
+        }
+      }
+    );
+    return Promise.resolve(response);
+  } catch (e) {
+    return Promise.reject(e);
+  }
+};
+
+export default function transactionalEmails(baseOptions) {
+  _baseOptions = baseOptions;
+
+  return {
+    /**
+     * Send an email designed and maintained in the HubSpot marketing Email Tool.
+     * See the {@link https://developers.hubspot.com/docs/methods/email/transactional_email/single-send-overview|developer docs} for full spec.
+     * @async
+     * @memberof hs/transactionalEmails
+     * @method singleSend
+     * @param {int} emailId The ID of the email to send, from the Email Tool when viewing a transactional email.
+     * @param {string} message A JSON object holding the recipient (in its to field) as well as other customizations that can be made on the fly.
+     * @param {object} contactProperties A list of JSON objects representing contact property values to set when sending the email.
+     * @param {object} customProperties A list of JSON objects representing property values to set when sending the email.
+     * @example
+     * const hs = new HubspotClient(props);
+     * hs.transactionalEmails.singleSend(emailId, message, contactProperties, customProperties).then(response => console.log(response));
+     * @returns {Promise}
+     */
+    singleSend
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import engagementsApi from './entities/engagements';
 import oauthApi from './entities/oauth';
 import contactsListsApi from './entities/contacts-lists';
 import emailSubscriptionsApi from './entities/email-subscriptions';
+import transactionalEmailsApi from './entities/transactional-emails';
 /**
 * HubSpotClient class
 * @example
@@ -38,6 +39,7 @@ class HubSpotClient {
   constructor(props) {
     Object.assign(this, { props });
   }
+
   /**
    * A collection of methods related to the Account API
    * @namespace hs/account
@@ -117,7 +119,7 @@ class HubSpotClient {
   get layouts() {
     return layoutsApi(this.props);
   }
-  
+
   /**
    * A collection of methods related to the Templates API
    * @namespace hs/templates
@@ -198,7 +200,7 @@ class HubSpotClient {
     return contactsListsApi(this.props);
   }
 
-    /**
+  /**
    * A collection of methods related to the Email Subscriptions API
    * @namespace hs/emailSubscriptions
    */
@@ -206,7 +208,13 @@ class HubSpotClient {
     return emailSubscriptionsApi(this.props);
   }
 
-
+  /**
+   * A collection of methods related to the Transactional Emails API
+   * @namespace hs/transactionalEmails
+   */
+  get transactionalEmails() {
+    return transactionalEmailsApi(this.props);
+  }
 }
 
 export default HubSpotClient;

--- a/test/transactional-emails.spec.js
+++ b/test/transactional-emails.spec.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+const { expect } = require('chai');
+const HubSpotClient = require('../dist/bundle.min');
+
+const {
+  E2E_TESTS_HAPI_KEY: hapikey,
+  E2E_TESTS_CONTACT_EMAIL,
+  E2E_TESTS_EMAIL_ID,
+} = process.env;
+
+const hs = new HubSpotClient({ hapikey });
+
+describe('Transactional Emails', () => {
+  describe('Single Send API', () => {
+    it('Sends an email', async () => {
+      const emailId = E2E_TESTS_EMAIL_ID;
+      const message = {
+        to: E2E_TESTS_CONTACT_EMAIL
+      };
+
+      const {
+        sendResult,
+        message: responseMessage,
+        eventId
+      } = await hs.transactionalEmails.singleSend(emailId, message);
+
+      expect(sendResult).not.to.be('');
+      expect(responseMessage).not.to.be('');
+      if (sendResult === 'SENT') {
+        expect(eventId).not.to.be('');
+      }
+
+      return Promise.resolve();
+    });
+  });
+});


### PR DESCRIPTION
Adds support for Transactional emails: Single Send API

https://developers.hubspot.com/docs/methods/email/transactional_email/single-send-overview

Fixes CONTRIBUTING ordered list numbers.