### PR TITLE
Fix contacts.getRecentlyModified returning 404

### DIFF
--- a/src/entities/contacts.js
+++ b/src/entities/contacts.js
@@ -179,7 +179,7 @@ const getContacts = async options => {
 const getRecentlyModified = async options => {
   try {
     requiresAuthentication(_baseOptions);
-    const mergedProps = Object.assign({}, defaults, _baseOptions, options);
+    const mergedProps = Object.assign({}, _baseOptions, options);
     const recentlyModifiedContacts = await createRequest(
       constants.api.contacts.getRecentlyModified,
       {},


### PR DESCRIPTION
Currently returns 404 from an authentication problem.
Removing defaults parameters from the Api call ( propertyMode & formSubmissionMode) returns data correctly.
See issue #77