### PR TITLE
Create return data obscured by return message

### DIFF
--- a/src/entities/contacts.js
+++ b/src/entities/contacts.js
@@ -72,14 +72,14 @@ const createOrUpdateContact = async obj => {
         value: obj[key]
       }))
     };
-    await createRequest(
+    const response = await createRequest(
       constants.api.contacts.createContact,
       { method, body, email },
       _baseOptions
     );
-    return Promise.resolve({
-      msg: `Successfully updated contact details for ${email}`
-    });
+    return Promise.resolve(
+      response.data;
+    );
   } catch (e) {
     return Promise.reject(e);
   }


### PR DESCRIPTION
I believe when using an API for inserting data it is absolutely crucial to know:
- Result: Ok / Failed
- ID of the new object

In this case as the method is a upsert, we also need to know if the record is actually new.
This information is provided in the API response.data correctly, 
```
{ vid: 2402451, isNew: true }
```
but it's never returned to the user of this library. I suspect many other methods are also hiding important information behind an apparent simple interface.

This code is unfortunately untested, but it's a mirror of the custom function I made and tested.