### PR TITLE
Return correct response for contact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-api",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-api",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "description": "HubSpot API Wrapper",
   "keywords": [
     "hubspot",

--- a/src/entities/contacts.js
+++ b/src/entities/contacts.js
@@ -77,7 +77,7 @@ const createOrUpdateContact = async obj => {
       { method, body, email },
       _baseOptions
     );
-    return Promise.resolve(response.data);
+    return Promise.resolve(response);
   } catch (e) {
     return Promise.reject(e);
   }


### PR DESCRIPTION
Hi Support,

We've re-opened https://github.com/HubSpotWebTeam/hs-node-api/pull/88

@robhuzzey noticed when creating & updating contacts that the response was coming back undefined.

After some investigation, we realised that the method was attempting to return response.data when in fact the createRequest method was already returning response.data.

This PR fixes this issue.

Thank you.
Trussle Team.